### PR TITLE
[maintenance] indicate that integration has been moved to dagster-io/community-integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> This integration has been moved to [dagster-io/community-integrations](https://github.com/dagster-io/community-integrations/tree/main/libraries/dagster-hex). Please open new pull requests and issues in that repository instead. Thank you!
+
 # Hex Dagster Library
 
 ### Installation


### PR DESCRIPTION
Closes https://github.com/hex-inc/dagster-hex/issues/7

---

Renders in the README like so:

<img width="973" alt="image" src="https://github.com/user-attachments/assets/f2181228-6578-4f4e-8d8e-c857c92c10db">
